### PR TITLE
生成結果が表示されない場合、アラートを表示する。

### DIFF
--- a/script.js
+++ b/script.js
@@ -138,7 +138,14 @@ window.onload = function() {
         ctx.fillStyle = '#747474';  // 文字色
         ctx.fillText(finalText, canvas.width / 2, textCenter + lineSpacing + baseFontSize);
 
-        resultImage.src = canvas.toDataURL();
+        let result = canvas.toDataURL();
+        
+        if (result === "data:,") {
+            alert ("フレームの生成に失敗しました。\n画像の横幅、横幅を小さくして試してみてください。");
+            return;
+        }
+
+        resultImage.src = result;
     }
 
     function displayContents(exifData) {


### PR DESCRIPTION
canvasのリミットを越えた場合、結果が表示されず、生成の段階でdata URIに内容が存在しない。
そこで、結果が表示されない場合は、生成に失敗した旨とその対応を表示するアラートを追加した。